### PR TITLE
Update monolog version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "LGPL-3.0+",
     "require": {
         "php": ">=5.4",
-        "symfony/monolog-bundle": "2.3.*"
+        "symfony/monolog-bundle": "~2.4"
     },
     "autoload": {
         "psr-0": { "Lasso\\MultilogBundle": "" }


### PR DESCRIPTION
This adds support for monolog 2.4 which is needed for symfony 2.4
